### PR TITLE
[data-api][m] - create view route

### DIFF
--- a/ckanext/bankofengland/actions.py
+++ b/ckanext/bankofengland/actions.py
@@ -1,0 +1,80 @@
+import requests
+import ckan.plugins.toolkit as toolkit
+from ckan.common import config
+
+
+def build_id(input):
+    return "".join(input)
+
+
+def build_joins(input):
+    if len(input) == 1:
+        return ""
+    return "".join(list(map(lambda string: f'JOIN {string} USING("Date") ', input[1:])))
+
+
+def build_sql(input):
+    return "CREATE VIEW {table_name} AS SELECT {first_table}.\"Date\", {list_of_tables} FROM {first_table} {joins}".format(table_name = build_id(input), first_table=input[0], list_of_tables=", ".join(f'{x}."{x.upper()}"' for x in input), joins=build_joins(input))
+
+
+def add_permissions(table_name):
+    url = config.get("ckanext.bankofengland.hasura_url") + "/v1/metadata"
+    body = {
+        "type": "pg_create_select_permission",
+        "args": {
+            "source": config.get("ckanext.bankofengland.hasura_db"),
+            "table": table_name,
+            "role": "anon",
+            "permission": {"columns": "*", "filter": {}, "allow_aggregations": True},
+        },
+    }
+    headers = {
+        "X-Hasura-Role": "admin",
+        "X-Hasura-Admin-Secret": config.get("ckanext.bankofengland.hasura_admin_key"),
+    }
+    response = requests.post(url, json=body, headers=headers)
+    return response.status_code
+
+
+def track_view(table_name):
+    url = config.get("ckanext.bankofengland.hasura_url") + "/v1/metadata"
+    body = {
+        "type": "pg_track_table",
+        "args": {
+            "source": config.get("ckanext.bankofengland.hasura_db"),
+            "table": table_name,
+        },
+    }
+    headers = {
+        "X-Hasura-Role": "admin",
+        "X-Hasura-Admin-Secret": config.get("ckanext.bankofengland.hasura_admin_key"),
+    }
+    response = requests.post(url, json=body, headers=headers)
+    return response.status_code
+
+
+def run_sql(query):
+    url = config.get("ckanext.bankofengland.hasura_url") + "/v2/query"
+    body = {
+        "type": "run_sql",
+        "args": {"source": config.get("ckanext.bankofengland.hasura_db"), "sql": query},
+    }
+    headers = {
+        "X-Hasura-Role": "admin",
+        "X-Hasura-Admin-Secret": config.get("ckanext.bankofengland.hasura_admin_key"),
+    }
+    response = requests.post(url, json=body, headers=headers)
+    return response.status_code
+
+
+def create_view(context, data_dict):
+    if "tables" not in data_dict:
+        raise toolkit.ValidationError("Missing tables value in input")
+    if len(data_dict["tables"]) == 0:
+        raise toolkit.ValidationError("Need to have at least one table")
+    for table in data_dict["tables"]:
+        if len(table) != 7:
+            raise toolkit.ValidationError("Invalid table name")
+    run_sql(build_sql(data_dict["tables"]))
+    track_view(build_id(data_dict["tables"]))
+    return add_permissions(build_id(data_dict["tables"]))

--- a/ckanext/bankofengland/plugin.py
+++ b/ckanext/bankofengland/plugin.py
@@ -1,9 +1,12 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
+from ckanext.bankofengland import actions
 
 class BankofenglandPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.IConfigurable)
+    plugins.implements(plugins.IActions)
 
     # IConfigurer
 
@@ -11,3 +14,25 @@ class BankofenglandPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'bankofengland')
+
+    # IConfigurable
+
+    def configure(self, config):
+        # Certain config options must exists for the plugin to work. Raise an
+        # exception if they're missing.
+        missing_config = "{0} is not configured. Please amend your .ini file."
+        config_options = (
+            'ckanext.bankofengland.hasura_url',
+            'ckanext.bankofengland.hasura_admin_key',
+            'ckanext.bankofengland.hasura_db',
+        )
+        for option in config_options:
+            if not config.get(option, None):
+                raise RuntimeError(missing_config.format(option))
+    
+    #IActions
+    def get_actions(self):
+        return {
+            'create_view': actions.create_view
+        }
+


### PR DESCRIPTION
This PR creates a `create_view` route. This route takes as input a list of tables with 7 characters as shown below.

```
{
    "tables": ["lpwbf82", "dpqtaeb"]
}
```

These tables need to:
1. Have already been tracked by Hasura, in other worlds, i need to be able to query them in the frontend for instance
2. They need to follow the bank of england specification:
  - Have only two columns(Date and Numeric)
  - The numeric column needs to have the same name as the table itself
  
 Once you provide that it will make 3 things, first it will run a SQL which essentially creates a custom view in the Hasura DB joining the list of tables by the Date column. The name for now is just a joining of the table names(But this needs to be changed)
 
 In the example below something like 
 
 ```
 CREATE VIEW lpwbf82dpqtaeb AS SELECT lpwbf82.\"Date\",  dpqtaeb."DPQTAEB" FROM lpwbf82 JOIN dpqtaeb USING("Date")
 ```
 
 Once we do that the next step is to track that view(`track_view` function) and after that add the necessary permissions(By default Hasura will leave everything private to anon users) 
 
Once we do that we can just query the table normaly using for instance the `tables` route in the frontend. You can test it [here](https://boe.portal.datopian.com/tables/lpwbf82dpqtaeb) altough we need to do some small work here 