### PR TITLE
[tags][m] - added thesauros to automatically add related tags

### DIFF
--- a/ckanext/bankofengland/actions.py
+++ b/ckanext/bankofengland/actions.py
@@ -66,7 +66,6 @@ def run_sql(query):
     response = requests.post(url, json=body, headers=headers)
     return response.status_code
 
-
 def create_view(context, data_dict):
     if "tables" not in data_dict:
         raise toolkit.ValidationError("Missing tables value in input")
@@ -78,3 +77,35 @@ def create_view(context, data_dict):
     run_sql(build_sql(data_dict["tables"]))
     track_view(build_id(data_dict["tables"]))
     return add_permissions(build_id(data_dict["tables"]))
+
+def get_related_tags(tag):
+    thesauros = toolkit.get_action('package_show')(None, { 'id': 'thesauros' })
+    thesauros_base_terms_resource = list(filter(lambda x: x['name'] == 'base_term_thesauros', thesauros['resources']))[0]
+    thesauros_alias_terms_resource = list(filter(lambda x: x['name'] == 'alias_terms_thesauros', thesauros['resources']))[0]
+    base_term_id = toolkit.get_action('datastore_search')(None, { 'resource_id': thesauros_base_terms_resource['id'], 'filters' : { 'BASE_TERM_UNSTEMMED': tag}, 'limit': 1000 })
+    if len(base_term_id['records']) == 0:
+        return [tag]
+    else:
+        alias_terms = toolkit.get_action('datastore_search')(None, { 'resource_id': thesauros_alias_terms_resource['id'], 'filters' : { 'BASE_TERM_ID': base_term_id['records'][0]['BASE_TERM_ID']}, 'limit': 1000 })
+        return [term['ALIAS_TERM_UNSTEMMED'] for term in list(alias_terms['records'])]
+
+def flatten(l):
+    return [item for sublist in l for item in sublist]
+
+@toolkit.chained_action
+def package_create(original_action, context, data_dict):
+    tags = data_dict['tags'] if 'tags' in data_dict else []
+    tags = [tag['name'] for tag in tags ]
+    new_tags = [{'name': tag_name, 'state': 'active' } for tag_name in flatten([get_related_tags(tag) for tag in tags])]
+    data_dict['tags'] = new_tags
+    result = original_action(context, data_dict)
+    return result
+
+@toolkit.chained_action
+def package_update(original_action, context, data_dict):
+    tags = data_dict['tags'] if 'tags' in data_dict else []
+    tags = [tag['name'] for tag in tags ]
+    new_tags = [{'name': tag_name, 'state': 'active' } for tag_name in flatten([get_related_tags(tag) for tag in tags])]
+    data_dict['tags'] = new_tags
+    result = original_action(context, data_dict)
+    return result

--- a/ckanext/bankofengland/actions.py
+++ b/ckanext/bankofengland/actions.py
@@ -4,7 +4,7 @@ from ckan.common import config
 
 
 def build_id(input):
-    return "".join(input)
+    return "_".join(input.sort())
 
 
 def build_joins(input):

--- a/ckanext/bankofengland/plugin.py
+++ b/ckanext/bankofengland/plugin.py
@@ -3,7 +3,7 @@ import logging
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
-from ckanext.bankofengland import actions
+from ckanext.bankofengland import actions, validators
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ class BankofenglandPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IValidators)
 
     # IConfigurer
 
@@ -45,6 +46,12 @@ class BankofenglandPlugin(plugins.SingletonPlugin):
         for option in config_options:
             if not config.get(option, None):
                 raise RuntimeError(missing_config.format(option))
+
+    def get_validators(self):
+        return {
+            "tag_length_validator": validators.tag_length_validator,
+            "tag_name_validator": validators.tag_name_validator
+        }
 
     #IActions
     def get_actions(self):

--- a/ckanext/bankofengland/plugin.py
+++ b/ckanext/bankofengland/plugin.py
@@ -49,5 +49,7 @@ class BankofenglandPlugin(plugins.SingletonPlugin):
     #IActions
     def get_actions(self):
         return {
-            'create_view': actions.create_view
+            'create_view': actions.create_view,
+            'package_create': actions.package_create,
+            'package_update': actions.package_update
         }

--- a/ckanext/bankofengland/validators.py
+++ b/ckanext/bankofengland/validators.py
@@ -1,0 +1,5 @@
+def tag_length_validator(value, context):
+    return value
+
+def tag_name_validator(value, context):
+    return value


### PR DESCRIPTION
This requires the existance of a package named "thesauros" with a resource named "base_term_thesauros" and another named "alias_term_thesauros" as shown below

![image](https://user-images.githubusercontent.com/11317382/220931898-6c18ffdd-19c4-4508-9a37-dd52926c9c89.png)

These are the files used(note that they need to be datastore ready)
[base_term_thesauros.csv](https://github.com/datopian/ckanext-bankofengland/files/10814371/base_term_thesauros.csv)
[alias_terms_thesauros.csv](https://github.com/datopian/ckanext-bankofengland/files/10814374/alias_terms_thesauros.csv)

