### PR TITLE
Add API action get_related_datasets

### DIFF
--- a/ckanext/bankofengland/actions.py
+++ b/ckanext/bankofengland/actions.py
@@ -404,6 +404,14 @@ def delete_footnote(context, data_dict):
 
 @toolkit.side_effect_free
 def get_related_datasets(context, data_dict):
+    dataset_id = data_dict.get('id')
+
+    if not dataset_id:
+        raise toolkit.ValidationError(
+            'No dataset id provided. Please provide an id '
+            'using the following format "?id=<DATASET_ID>"'
+        )
+
     rows = data_dict.get('rows', 10)
     percent = data_dict.get('percent', 0.8)
 
@@ -413,7 +421,7 @@ def get_related_datasets(context, data_dict):
     if not isinstance(percent, float):
         percent = float(percent)
 
-    dataset = toolkit.get_action('package_show')(context, data_dict)
+    dataset = toolkit.get_action('package_show')(context, {'id': dataset_id})
 
     metadata_fields = [
         'boe_dim_counterparty_sector_of_reporter',

--- a/ckanext/bankofengland/plugin.py
+++ b/ckanext/bankofengland/plugin.py
@@ -119,6 +119,7 @@ class BankofenglandPlugin(plugins.SingletonPlugin):
             'create_footnote': actions.create_footnote,
             'update_footnote': actions.update_footnote,
             'delete_footnote': actions.delete_footnote,
+            'get_related_datasets': actions.get_related_datasets,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
I'm currently using the following fields to compare:

```
    metadata_fields = [
        'boe_dim_counterparty_sector_of_reporter',
        'child',
        'eba_dim_bas_base',
        'eba_dim_cps_counterparty_sector',
        'eba_dim_cud_currency_of_denomination_of_the_reported_position',
        'eba_dim_mcb_instrument',
        'eba_dim_mcy_main_category',
        'eba_dim_rcp_residence_of_counterparty',
        'eba_dim_tri_type_of_risk',
        'granularity',
        'market_value_by',
        'metrics',
        'owner_org',
        'tags',
        'groups'
    ]
```

For `tags` and `groups`, I iterate over each one, so for each `tag` and `group` has a weight of 1. This means that if the dataset IN has 50 tags, then when comparing to other datasets, the percent will be weighed against 50 + the count of other metadata. If this dataset is compared to another and the second dataset has 10 matching tags, then it counts as a 20% match in tags alone. We can go with this for now and if you have any better ideas, let me know.

The API call is `get_related_datasets`, and it takes the following params:
```
id=<DATASET_ID> (required)
rows=<NUM_OF_RESULTS> (optional—default 10)
percent=<PERCENT_FLOAT> (optional—default 0.8)
```

